### PR TITLE
Release Hyrule 0.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2021 the authors.
+Copyright 2022 the authors.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -3,9 +3,9 @@
 Unreleased
 ==============================
 
-This is the first release of Hyrule per se. Changes are described
-relative to the ancestors of Hyrule in Hy 1.0a3.
+This is the first release of Hyrule per se. The one change below is
+described relative to the ancestors of Hyrule in Hy 1.0a3.
 
-Other Breaking Changes
+Breaking Changes
 ------------------------------
 * `coll?` now returns `False` for `bytes` objects.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,81 +16,67 @@ Reference
 ----------------------------------------------------------------------
 
 .. hy:automodule:: hyrule.anaphoric
-  :members:
-  :macros:
-  :tags:
+  :macros: #%, ap-if, ap-each, ap-each-while, ap-map, ap-map-when,
+    ap-filter, ap-reject, ap-dotimes, ap-first, ap-last, ap-reduce
 
 ``argmove`` — Macros for calls with unusual argument placement 
 ----------------------------------------------------------------------
 
 .. hy:automodule:: hyrule.argmove
-  :members:
-  :macros:
-  :tags:
+  :macros: ->, ->>, as->, doto
 
 ``collections`` — Tools for data structures
 ----------------------------------------------------------------------
 
 .. hy:automodule:: hyrule.collections
-  :members:
-  :macros:
-  :tags:
+  :members: postwalk, prewalk, walk
+  :macros: #:, assoc, ncut
 
 ``control`` — Control structures
 ----------------------------------------------------------------------
 
 .. hy:automodule:: hyrule.control
-  :members:
-  :macros:
-  :tags:
+  :macros: cfor, defmain, do-n, ifp, lif, list-n, loop, unless
 
 ``destructure`` — Macros for destructuring collections
 ----------------------------------------------------------------------
 
 .. hy:automodule:: hyrule.destructure
-  :members:
-  :macros:
-  :tags:
+  :macros: defn+, defn/a+, dict=:, fn+, fn/a+, let+, setv+
 
 ``iterables`` — Tools for iterable objects
 ----------------------------------------------------------------------
 
 .. hy:automodule:: hyrule.iterables
-  :members:
-  :macros:
-  :tags:
+  :members: butlast, coll?, distinct, drop-last, flatten, rest
 
 ``macrotools`` — Tools for writing and handling macros
 ----------------------------------------------------------------------
 
 .. hy:automodule:: hyrule.macrotools
-  :members:
-  :macros:
-  :tags:
+  :members: macroexpand-all
+  :macros: defmacro/g!, defmacro!, with-gensyms
 
 ``pprint`` — Pretty-printing data structures
 ----------------------------------------------------------------------
 
 .. hy:automodule:: hyrule.hypprint
-  :members:
-  :macros:
-  :tags:
+  :members: PrettyPrinter, pformat, pp, pprint, saferepr,
+      readable?, recursive?
 
 ``sequences`` — Lazy, indexable iterables
 ----------------------------------------------------------------------
 
 .. hy:automodule:: hyrule.sequences
-  :members:
-  :macros:
-  :tags:
+  :members: end-sequence
+  :macros: defseq, seq
 
 ``misc`` — Everything else
 ----------------------------------------------------------------------
 
 .. hy:automodule:: hyrule.misc
-  :members:
-  :macros:
-  :tags:
+  :members: constantly, dec, inc, parse-args, xor
+  :macros: comment, of, profile/calls, profile/cpu, smacrolet
 
 Contributing to Hyrule
 ======================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,7 +71,7 @@ Reference
 ``pprint`` — Pretty-printing data structures
 ----------------------------------------------------------------------
 
-.. hy:automodule:: hyrule.pprint
+.. hy:automodule:: hyrule.hypprint
   :members:
   :macros:
   :tags:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,14 +60,6 @@ Reference
   :macros:
   :tags:
 
-``let`` — Classical Lisp scoping
-----------------------------------------------------------------------
-
-.. hy:automodule:: hyrule.let
-  :members:
-  :macros:
-  :tags:
-
 ``macrotools`` — Tools for writing and handling macros
 ----------------------------------------------------------------------
 

--- a/hyrule/__init__.py
+++ b/hyrule/__init__.py
@@ -1,6 +1,8 @@
 # We use an `__init__.py` instead of `__init__.hy` so that importing
 # from Python works even if `hy` hasn't been imported yet.
 
+__version__ = 'unreleased'
+
 import hy
 hy.macros.require('hyrule.hy_init',
    # The Python equivalent of `(require hyrule.hy-init *)`

--- a/hyrule/control.hy
+++ b/hyrule/control.hy
@@ -13,6 +13,7 @@
   to ``(f (gfor ...))``.
 
   Examples:
+
   ::
      => (cfor tuple x (range 10) :if (% x 2) x)
      (, 1 3 5 7 9)

--- a/hyrule/control.hy
+++ b/hyrule/control.hy
@@ -1,5 +1,5 @@
 (require
-  hyrule.macrotools [defmacro/g!])
+  hyrule.macrotools [defmacro/g! defmacro!])
 (import
   hyrule.collections [prewalk]
   hyrule.misc [inc])
@@ -116,6 +116,48 @@
      (setv ~retval ((fn [~@(or args `[#* ~restval])] ~@body) #* sys.argv))
      (if (isinstance ~retval int)
        (sys.exit ~retval))))
+
+
+(defmacro! ifp [o!pred o!expr #* clauses]
+  "Takes a binary predicate ``pred``, an expression ``expr``, and a set of
+  clauses. Each clause can be of the form ``cond res`` or ``cond :>> res``. For
+  each clause, if ``(pred cond expr)`` evaluates to true, returns ``res`` in
+  the first case or ``(res (pred cond expr))`` in the second case. If the last
+  clause is just ``res``, then it is returned as a default, else ``None.``
+
+  Examples:
+    ::
+
+       => (ifp = 4
+       ...   3 :do-something
+       ...   5 :do-something-else
+       ...   :no-match)
+       :no-match
+
+    ::
+
+       => (ifp (fn [x f] (f x)) ':a
+       ...   {:b 1} :>> inc
+       ...   {:a 1} :>> dec)
+       0
+  "
+  (defn emit [pred expr args]
+    (setv n (if (and (> (len args) 1) (= :>> (get args 1))) 3 2)
+          [clause more] [(cut args n) (cut args n None)]
+          n (len clause)
+          test (hy.gensym))
+    (cond
+      [(= 0 n) `(raise (TypeError (+ "no option for " (repr ~expr))))]
+      [(= 1 n) (get clause 0)]
+      [(= 2 n) `(if (~pred ~(get clause 0) ~expr)
+                    ~(get clause -1)
+                    ~(emit pred expr more))]
+      [True `(do
+               (setv ~test (~pred ~(get clause 0) ~expr))
+               (if ~test
+                   (~(get clause -1) ~test)
+                   ~(emit pred expr more)))]))
+  `~(emit g!pred g!expr clauses))
 
 
 (defmacro lif [#* args]

--- a/hyrule/destructure.hy
+++ b/hyrule/destructure.hy
@@ -7,12 +7,6 @@ their arguments.
 Introduction
 ============
 
-To use these macros, you need to require them like so:
-
-.. code-block:: hy
-
-    (require hy.contrib.destructure [setv+ fn+ defn+ let+ defn/a+ fn/a+])
-
 Destructuring allows one to easily peek inside a data structure and assign names to values within. For example,
 
 .. code-block:: hy

--- a/hyrule/destructure.hy
+++ b/hyrule/destructure.hy
@@ -104,55 +104,14 @@ Iterator patterns are specified using round brackets. They are the same as list 
 
 (require
   hyrule.argmove [->>]
-  hyrule.control [unless]
-  hyrule.macrotools [defmacro! defmacro/g!])
+  hyrule.control [unless ifp]
+  hyrule.macrotools [defmacro/g!])
 (import
   itertools [starmap chain count]
   functools [reduce]
   hy.pyops *
   hyrule.iterables [rest]
   hyrule.collections [by2s])
-
-(defmacro! ifp [o!pred o!expr #* clauses]
-  "Takes a binary predicate ``pred``, an expression ``expr``, and a set of
-  clauses. Each clause can be of the form ``cond res`` or ``cond :>> res``. For
-  each clause, if ``(pred cond expr)`` evaluates to true, returns ``res`` in
-  the first case or ``(res (pred cond expr))`` in the second case. If the last
-  clause is just ``res``, then it is returned as a default, else ``None.``
-
-  Examples:
-    ::
-
-       => (ifp = 4
-       ...   3 :do-something
-       ...   5 :do-something-else
-       ...   :no-match)
-       :no-match
-
-    ::
-
-       => (ifp (fn [x f] (f x)) ':a
-       ...   {:b 1} :>> inc
-       ...   {:a 1} :>> dec)
-       0
-  "
-  (defn emit [pred expr args]
-    (setv n (if (and (> (len args) 1) (= :>> (get args 1))) 3 2)
-          [clause more] [(cut args n) (cut args n None)]
-          n (len clause)
-          test (hy.gensym))
-    (cond
-      [(= 0 n) `(raise (TypeError (+ "no option for " (repr ~expr))))]
-      [(= 1 n) (get clause 0)]
-      [(= 2 n) `(if (~pred ~(get clause 0) ~expr)
-                    ~(get clause -1)
-                    ~(emit pred expr more))]
-      [True `(do
-               (setv ~test (~pred ~(get clause 0) ~expr))
-               (if ~test
-                   (~(get clause -1) ~test)
-                   ~(emit pred expr more)))]))
-  `~(emit g!pred g!expr clauses))
 
 (defmacro setv+ [#* pairs]
   "Assignment with destructuring for both mappings and iterables.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ setuptools.setup(
     description = 'A utility library for the Hy programming language',
     long_description = long_description,
     license = 'Expat',
-    url = "http://hylang.org/",
+    project_urls = dict(
+        Documentation = 'https://hyrule.readthedocs.io',
+        Source = 'https://github.com/hylang/hyrule'),
     platforms = ['any'],
     classifiers = [
         "Development Status :: 4 - Beta",

--- a/tests/test_pprint.hy
+++ b/tests/test_pprint.hy
@@ -1,0 +1,202 @@
+(import
+  pytest
+  io
+  pprint :as pypprint
+  hy._compat [PY3_8]
+  hy.contrib.pprint :as pprint)
+
+(defn large-list-b []
+  (list (range 200)))
+
+(defn large-list-a []
+  (setv out (list (range 100)))
+  (assoc out -12 (large-list-b))
+  out)
+
+(defn test-basic []
+  (setv pp (pprint.PrettyPrinter))
+  (for [safe (, 2 2.0 2j "abc" [3] (, 2 2) {3 3} b"def"
+                (bytearray b"ghi") True False None (large-list-a) (large-list-b))]
+    (assert (not (pprint.recursive? safe)))
+    (assert (pprint.readable? safe))
+    (assert (not (pp.isrecursive safe)))
+    (assert (pp.isreadable safe))))
+
+(defn test-knotted []
+  (setv a (large-list-a)
+        b (large-list-b))
+  (assoc a 50 b)
+  (assoc b 67 a)
+  (setv d (dict))
+  (assoc d 2 d)
+  (assoc d 1 (get d 2))
+  (assoc d 0 (get d 1))
+  (setv pp (pprint.PrettyPrinter))
+
+  (for [icky (, a b d (, d d))]
+    (assert (pprint.recursive? icky))
+    (assert (not (pprint.readable? icky)))
+    (assert (pp.isrecursive icky))
+    (assert (not (pp.isreadable icky))))
+
+  ;; Break the cycles
+  (d.clear)
+  (del (cut a None))
+  (del (cut b None))
+
+  (for [safe (, a b d (, d d))]
+    (assert (not (pprint.recursive? safe)))
+    (assert (pprint.readable? safe))
+    (assert (not (pp.isrecursive safe)))
+    (assert (pp.isreadable safe))))
+
+(defn test-unreadable []
+  (setv pp (pprint.PrettyPrinter))
+  (for [unreadable (, (type 3) pprint pprint.recursive?)]
+    (assert (not (pprint.recursive? unreadable)))
+    (assert (not (pprint.readable? unreadable)))
+    (assert (not (pp.isrecursive unreadable)))
+    (assert (not (pp.isreadable unreadable)))))
+
+(defn test-basic-line-wrap []
+  (setv o (dict :RPM_cal 0
+                :RPM_cal2 48059
+                :Speed_cal 0
+                :controldesk_runtime_us 0
+                :main_code_runtime_us 0
+                :read_io_runtime_us 0
+                :write_io_runtime_us 43690)
+        exp #[[
+{"RPM_cal" 0
+ "RPM_cal2" 48059
+ "Speed_cal" 0
+ "controldesk_runtime_us" 0
+ "main_code_runtime_us" 0
+ "read_io_runtime_us" 0
+ "write_io_runtime_us" 43690}]])
+  (assert (= (pprint.pformat o) exp))
+
+  ;; Lists
+  (setv o (list (range 100))
+        exp (% "[%s]" (.join "\n " (map str o))))
+  (assert (= (pprint.pformat o) exp))
+
+  ;; Tuples
+  (setv o (tuple (range 100))
+        exp (% "(, %s)" (.join "\n   " (map str o))))
+  (assert (= (pprint.pformat o) exp))
+
+  ;; Indent paramater
+  (setv o (list (range 100))
+        exp (% "[   %s]" (.join "\n    " (map str o))))
+  (assert (= (pprint.pformat o :indent 4) exp)))
+
+(defn test-nested-indentations []
+  (setv o1 (list (range 10))
+        o2 (dict :first 1 :second 2 :third 3)
+        o [o1 o2]
+        exp #[FOO[
+[   [0 1 2 3 4 5 6 7 8 9]
+    {"first" 1  "second" 2  "third" 3}]]FOO])
+  (assert (= (pprint.pformat o :indent 4 :width 39) exp))
+
+  (setv exp #[FOO[
+[   [0 1 2 3 4 5 6 7 8 9]
+    {   "first" 1
+        "second" 2
+        "third" 3}]]FOO])
+  (assert (= (pprint.pformat o :indent 4 :width 38) exp)))
+
+(defn test-width []
+  (defclass set2 [set])
+  (setv exp #[FOO[
+[[[[[[1 2 3]
+     "1 2"]]]]
+ {1 [1 2 3]
+  2 [12 34]}
+ "abc def ghi"
+ (, "ab cd ef")
+ #{1 23}
+ [[[[[1 2 3]
+     "1 2"]]]]]]FOO])
+
+  (setv o (hy.eval (hy.read-str exp)))
+  (assert (= (pprint.pformat o :width 16) exp))
+  (assert (= (pprint.pformat o :width 17) exp))
+  (assert (= (pprint.pformat o :width 22) exp))
+  (assert (= (pprint.pformat o :width 12) #[FOO[
+[[[[[[1
+      2
+      3]
+     "1 2"]]]]
+ {1 [1 2 3]
+  2 [12
+     34]}
+ (+ "abc "
+    "def "
+    "ghi")
+ (, (+ "ab "
+       "cd "
+       "ef"))
+ #{1 23}
+ [[[[[1
+      2
+      3]
+     "1 2"]]]]]]FOO])))
+
+(defn test-depth []
+  (setv nested-tuple (, 1 (, 2 (, 3 (, 4 (, 5 6)))))
+        nested-dict {1 {2 {3 {4 {5 {6 6}}}}}}
+        nested-list [1 [2 [3 [4 [5 [6 []]]]]]])
+  (assert (= (pprint.pformat nested-tuple) (hy.repr nested-tuple)))
+  (assert (= (pprint.pformat nested-dict) (hy.repr nested-dict)))
+  (assert (= (pprint.pformat nested-list) (hy.repr nested-list)))
+
+  (assert (= (pprint.pformat nested-tuple :depth 1) "(, 1 (, ...))"))
+  (assert (= (pprint.pformat nested-dict :depth 1) "{1 {...}}"))
+  (assert (= (pprint.pformat nested-list :depth 1) "[1 [...]]")))
+
+(defn test-str-wrap []
+  (setv fox "the quick brown fox jumped over the lazy dog")
+  ;; Level 1
+  (assert (= (pprint.pformat fox :width 20) #[[
+(+ "the quick brown "
+   "fox jumped over "
+   "the lazy dog")]]))
+
+  ;; Nested Levels
+  (assert (= (pprint.pformat (dict :a 1 :b fox :c 2) :width 26)
+             #[[
+{"a" 1
+ "b" (+ "the quick brown "
+        "fox jumped over "
+        "the lazy dog")
+ "c" 2}]])))
+
+(defn test-bytes-wrap []
+  "Check that multi-line pretty printed bytestrings
+  indent properly and prefer chunking in blocks of
+  length 4"
+  (setv letters b"abcdefghijklmnopqrstuvwxyz")
+  (assert (= (pprint.pformat letters :width 29) (hy.repr letters)))
+  (assert (= (pprint.pformat letters :width 22) #[[
+(+ b"abcdefghijklmnop"
+   b"qrstuvwxyz")]]))
+
+  (assert (= (pprint.pformat letters :width 21) #[[
+(+ b"abcdefghijkl"
+   b"mnopqrstuvwx"
+   b"yz")]]))
+
+  (assert (= (pprint.pformat [letters] :width 21) #[FOO[
+[(+ b"abcdefghijkl"
+    b"mnopqrstuvwx"
+    b"yz")]]FOO])))
+
+(defn test-sort-dicts []
+  (setv d (dict.fromkeys "cba"))
+  (if PY3_8
+      (assert (= (pprint.pformat d :sort-dicts False)
+                 #[[{"c" None  "b" None  "a" None}]]))
+      (with [e (pytest.raises ValueError)]
+        (pprint.pformat d :sort-dicts False))))

--- a/tests/test_pprint.hy
+++ b/tests/test_pprint.hy
@@ -1,41 +1,39 @@
 (import
   pytest
-  io
-  pprint :as pypprint
   hy._compat [PY3_8]
-  hy.contrib.pprint :as pprint)
+  hyrule [PrettyPrinter pformat recursive? readable?])
 
 (defn large-list-b []
   (list (range 200)))
 
 (defn large-list-a []
   (setv out (list (range 100)))
-  (assoc out -12 (large-list-b))
+  (setv (get out -12) (large-list-b))
   out)
 
 (defn test-basic []
-  (setv pp (pprint.PrettyPrinter))
+  (setv pp (PrettyPrinter))
   (for [safe (, 2 2.0 2j "abc" [3] (, 2 2) {3 3} b"def"
                 (bytearray b"ghi") True False None (large-list-a) (large-list-b))]
-    (assert (not (pprint.recursive? safe)))
-    (assert (pprint.readable? safe))
+    (assert (not (recursive? safe)))
+    (assert (readable? safe))
     (assert (not (pp.isrecursive safe)))
     (assert (pp.isreadable safe))))
 
 (defn test-knotted []
   (setv a (large-list-a)
-        b (large-list-b))
-  (assoc a 50 b)
-  (assoc b 67 a)
-  (setv d (dict))
-  (assoc d 2 d)
-  (assoc d 1 (get d 2))
-  (assoc d 0 (get d 1))
-  (setv pp (pprint.PrettyPrinter))
+        b (large-list-b)
+        (get a 50) b
+        (get b 67) a
+        d (dict)
+        (get d 2) d
+        (get d 1) (get d 2)
+        (get d 0) (get d 1))
+  (setv pp (PrettyPrinter))
 
   (for [icky (, a b d (, d d))]
-    (assert (pprint.recursive? icky))
-    (assert (not (pprint.readable? icky)))
+    (assert (recursive? icky))
+    (assert (not (readable? icky)))
     (assert (pp.isrecursive icky))
     (assert (not (pp.isreadable icky))))
 
@@ -45,16 +43,16 @@
   (del (cut b None))
 
   (for [safe (, a b d (, d d))]
-    (assert (not (pprint.recursive? safe)))
-    (assert (pprint.readable? safe))
+    (assert (not (recursive? safe)))
+    (assert (readable? safe))
     (assert (not (pp.isrecursive safe)))
     (assert (pp.isreadable safe))))
 
 (defn test-unreadable []
-  (setv pp (pprint.PrettyPrinter))
-  (for [unreadable (, (type 3) pprint pprint.recursive?)]
-    (assert (not (pprint.recursive? unreadable)))
-    (assert (not (pprint.readable? unreadable)))
+  (setv pp (PrettyPrinter))
+  (for [unreadable (, (type 3) pytest recursive?)]
+    (assert (not (recursive? unreadable)))
+    (assert (not (readable? unreadable)))
     (assert (not (pp.isrecursive unreadable)))
     (assert (not (pp.isreadable unreadable)))))
 
@@ -74,22 +72,22 @@
  "main_code_runtime_us" 0
  "read_io_runtime_us" 0
  "write_io_runtime_us" 43690}]])
-  (assert (= (pprint.pformat o) exp))
+  (assert (= (pformat o) exp))
 
   ;; Lists
   (setv o (list (range 100))
         exp (% "[%s]" (.join "\n " (map str o))))
-  (assert (= (pprint.pformat o) exp))
+  (assert (= (pformat o) exp))
 
   ;; Tuples
   (setv o (tuple (range 100))
         exp (% "(, %s)" (.join "\n   " (map str o))))
-  (assert (= (pprint.pformat o) exp))
+  (assert (= (pformat o) exp))
 
   ;; Indent paramater
   (setv o (list (range 100))
         exp (% "[   %s]" (.join "\n    " (map str o))))
-  (assert (= (pprint.pformat o :indent 4) exp)))
+  (assert (= (pformat o :indent 4) exp)))
 
 (defn test-nested-indentations []
   (setv o1 (list (range 10))
@@ -98,14 +96,14 @@
         exp #[FOO[
 [   [0 1 2 3 4 5 6 7 8 9]
     {"first" 1  "second" 2  "third" 3}]]FOO])
-  (assert (= (pprint.pformat o :indent 4 :width 39) exp))
+  (assert (= (pformat o :indent 4 :width 39) exp))
 
   (setv exp #[FOO[
 [   [0 1 2 3 4 5 6 7 8 9]
     {   "first" 1
         "second" 2
         "third" 3}]]FOO])
-  (assert (= (pprint.pformat o :indent 4 :width 38) exp)))
+  (assert (= (pformat o :indent 4 :width 38) exp)))
 
 (defn test-width []
   (defclass set2 [set])
@@ -121,10 +119,10 @@
      "1 2"]]]]]]FOO])
 
   (setv o (hy.eval (hy.read-str exp)))
-  (assert (= (pprint.pformat o :width 16) exp))
-  (assert (= (pprint.pformat o :width 17) exp))
-  (assert (= (pprint.pformat o :width 22) exp))
-  (assert (= (pprint.pformat o :width 12) #[FOO[
+  (assert (= (pformat o :width 16) exp))
+  (assert (= (pformat o :width 17) exp))
+  (assert (= (pformat o :width 22) exp))
+  (assert (= (pformat o :width 12) #[FOO[
 [[[[[[1
       2
       3]
@@ -148,24 +146,24 @@
   (setv nested-tuple (, 1 (, 2 (, 3 (, 4 (, 5 6)))))
         nested-dict {1 {2 {3 {4 {5 {6 6}}}}}}
         nested-list [1 [2 [3 [4 [5 [6 []]]]]]])
-  (assert (= (pprint.pformat nested-tuple) (hy.repr nested-tuple)))
-  (assert (= (pprint.pformat nested-dict) (hy.repr nested-dict)))
-  (assert (= (pprint.pformat nested-list) (hy.repr nested-list)))
+  (assert (= (pformat nested-tuple) (hy.repr nested-tuple)))
+  (assert (= (pformat nested-dict) (hy.repr nested-dict)))
+  (assert (= (pformat nested-list) (hy.repr nested-list)))
 
-  (assert (= (pprint.pformat nested-tuple :depth 1) "(, 1 (, ...))"))
-  (assert (= (pprint.pformat nested-dict :depth 1) "{1 {...}}"))
-  (assert (= (pprint.pformat nested-list :depth 1) "[1 [...]]")))
+  (assert (= (pformat nested-tuple :depth 1) "(, 1 (, ...))"))
+  (assert (= (pformat nested-dict :depth 1) "{1 {...}}"))
+  (assert (= (pformat nested-list :depth 1) "[1 [...]]")))
 
 (defn test-str-wrap []
   (setv fox "the quick brown fox jumped over the lazy dog")
   ;; Level 1
-  (assert (= (pprint.pformat fox :width 20) #[[
+  (assert (= (pformat fox :width 20) #[[
 (+ "the quick brown "
    "fox jumped over "
    "the lazy dog")]]))
 
   ;; Nested Levels
-  (assert (= (pprint.pformat (dict :a 1 :b fox :c 2) :width 26)
+  (assert (= (pformat (dict :a 1 :b fox :c 2) :width 26)
              #[[
 {"a" 1
  "b" (+ "the quick brown "
@@ -178,17 +176,17 @@
   indent properly and prefer chunking in blocks of
   length 4"
   (setv letters b"abcdefghijklmnopqrstuvwxyz")
-  (assert (= (pprint.pformat letters :width 29) (hy.repr letters)))
-  (assert (= (pprint.pformat letters :width 22) #[[
+  (assert (= (pformat letters :width 29) (hy.repr letters)))
+  (assert (= (pformat letters :width 22) #[[
 (+ b"abcdefghijklmnop"
    b"qrstuvwxyz")]]))
 
-  (assert (= (pprint.pformat letters :width 21) #[[
+  (assert (= (pformat letters :width 21) #[[
 (+ b"abcdefghijkl"
    b"mnopqrstuvwx"
    b"yz")]]))
 
-  (assert (= (pprint.pformat [letters] :width 21) #[FOO[
+  (assert (= (pformat [letters] :width 21) #[FOO[
 [(+ b"abcdefghijkl"
     b"mnopqrstuvwx"
     b"yz")]]FOO])))
@@ -196,7 +194,7 @@
 (defn test-sort-dicts []
   (setv d (dict.fromkeys "cba"))
   (if PY3_8
-      (assert (= (pprint.pformat d :sort-dicts False)
+      (assert (= (pformat d :sort-dicts False)
                  #[[{"c" None  "b" None  "a" None}]]))
       (with [e (pytest.raises ValueError)]
-        (pprint.pformat d :sort-dicts False))))
+        (pformat d :sort-dicts False))))


### PR DESCRIPTION
Fixes #10.

~~I won't actually merge the last commit into master, so Hyrule master will continue to depend on Hy master instead of the latest alpha.~~ Popped out into the following patch:

```diff
From 32ab8a15b7c0a257c42ee6b58e16c3f81553794b Mon Sep 17 00:00:00 2001
From: Kodi Arfer <x>
Date: Fri, 7 Jan 2022 16:30:21 -0500
Subject: [PATCH] Set versioning for release

---
 hyrule/__init__.py | 2 +-
 setup.py           | 4 ++--
 2 files changed, 3 insertions(+), 3 deletions(-)

diff --git a/hyrule/__init__.py b/hyrule/__init__.py
index f86dde2..6522be5 100644
--- a/hyrule/__init__.py
+++ b/hyrule/__init__.py
@@ -1,7 +1,7 @@
 # We use an `__init__.py` instead of `__init__.hy` so that importing
 # from Python works even if `hy` hasn't been imported yet.
 
-__version__ = 'unreleased'
+__version__ = '0.1'
 
 import hy
 hy.macros.require('hyrule.hy_init',
diff --git a/setup.py b/setup.py
index 6621c8d..9f264b3 100644
--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@ with open('README.rst', 'r') as o:
 
 setuptools.setup(
     name = 'hyrule',
-    version = None,
+    version = '0.1',
     install_requires = [
-        'hy @ git+https://github.com/hylang/hy@master#egg=hy-1.0'],
+        'hy == 1.0a4'],
     extras_require = dict(
         docs = [
             'Sphinx == 3.5.4',
-- 
2.32.0
```