### PR TITLE
Replace `ifp` with `branch`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -3,9 +3,14 @@
 Unreleased
 ==============================
 
+Removals
+------------------------------
+* `ifp` has been removed. Use `branch` instead.
+
 New Features
 ------------------------------
 * New macro `block`.
+* New macros `branch`, `ebranch`, `case`, and `ecase`.
 
 0.1 (released 2022-01-09)
 ==============================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,7 +36,8 @@ Reference
 ----------------------------------------------------------------------
 
 .. hy:automodule:: hyrule.control
-  :macros: block, cfor, defmain, do-n, ifp, lif, list-n, loop, unless
+  :macros: block, branch, ebranch, case, ecase, cfor, defmain, do-n,
+    ifp, lif, list-n, loop, unless
 
 ``destructure`` — Macros for destructuring collections
 ----------------------------------------------------------------------

--- a/hyrule/anaphoric.hy
+++ b/hyrule/anaphoric.hy
@@ -277,7 +277,7 @@ variable name, as in ``(print \"My favorite Stephen King book is\" 'it)``."
 
 (defn recur-sym-replace [d form]
   "Recursive symbol replacement."
-  (import hyrule [coll?])
+  (import hyrule.iterables [coll?])
   (cond
     [(isinstance form hy.models.Symbol)
       (.get d form form)]

--- a/hyrule/control.hy
+++ b/hyrule/control.hy
@@ -141,48 +141,6 @@
        (sys.exit ~retval))))
 
 
-(defmacro! ifp [o!pred o!expr #* clauses]
-  "Takes a binary predicate ``pred``, an expression ``expr``, and a set of
-  clauses. Each clause can be of the form ``cond res`` or ``cond :>> res``. For
-  each clause, if ``(pred cond expr)`` evaluates to true, returns ``res`` in
-  the first case or ``(res (pred cond expr))`` in the second case. If the last
-  clause is just ``res``, then it is returned as a default, else ``None.``
-
-  Examples:
-    ::
-
-       => (ifp = 4
-       ...   3 :do-something
-       ...   5 :do-something-else
-       ...   :no-match)
-       :no-match
-
-    ::
-
-       => (ifp (fn [x f] (f x)) ':a
-       ...   {:b 1} :>> inc
-       ...   {:a 1} :>> dec)
-       0
-  "
-  (defn emit [pred expr args]
-    (setv n (if (and (> (len args) 1) (= :>> (get args 1))) 3 2)
-          [clause more] [(cut args n) (cut args n None)]
-          n (len clause)
-          test (hy.gensym))
-    (cond
-      [(= 0 n) `(raise (TypeError (+ "no option for " (repr ~expr))))]
-      [(= 1 n) (get clause 0)]
-      [(= 2 n) `(if (~pred ~(get clause 0) ~expr)
-                    ~(get clause -1)
-                    ~(emit pred expr more))]
-      [True `(do
-               (setv ~test (~pred ~(get clause 0) ~expr))
-               (if ~test
-                   (~(get clause -1) ~test)
-                   ~(emit pred expr more)))]))
-  `~(emit g!pred g!expr clauses))
-
-
 (defmacro lif [#* args]
   "Like `if`, but anything that is not None is considered true.
 

--- a/hyrule/control.hy
+++ b/hyrule/control.hy
@@ -2,7 +2,8 @@
   hyrule.macrotools [defmacro/g! defmacro!])
 (import
   hyrule.anaphoric [recur-sym-replace]
-  hyrule.collections [prewalk coll? by2s]
+  hyrule.collections [prewalk by2s]
+  hyrule.iterables [coll?]
   hyrule.misc [inc])
 
 


### PR DESCRIPTION
Closes #20.
Closes #8.

I haven't added documentation yet in case we want to change the semantics (or the syntax, or the names) first. I opted not to allow `case` to check membership in a list, like it can in Common Lisp, so you can check equality with a list. You can still use `branch` if you want to compare stuff with `in` instead of `=`.