### PR TITLE
Use `let` to replace symbols in `branch`

### DIFF
--- a/hyrule/control.hy
+++ b/hyrule/control.hy
@@ -1,7 +1,6 @@
 (require
   hyrule.macrotools [defmacro/g! defmacro!])
 (import
-  hyrule.anaphoric [recur-sym-replace]
   hyrule.collections [prewalk by2s]
   hyrule.iterables [coll?]
   hyrule.misc [inc])
@@ -70,14 +69,14 @@
 (defn _branch [tester rest]
   (when (% (len rest) 2)
     (raise (TypeError "each case-form needs a result-form")))
-  (setv it (hy.gensym "branch-it"))
-  `(cond ~@(gfor [case result] (by2s rest) `[
-    ~(if (= case 'else)
-      'True
-      `(do
-        (setv ~it ~case)
-        ~(recur-sym-replace {'it it} tester)))
-    ~result])))
+  `(let [it None]
+    (cond ~@(gfor [case result] (by2s rest) `[
+      ~(if (= case 'else)
+        'True
+        `(do
+          (setv it ~case)
+          ~tester))
+      ~result]))))
 
 
 (defmacro case [key #* rest]

--- a/tests/test_control.hy
+++ b/tests/test_control.hy
@@ -200,6 +200,30 @@
     (atest -6) "e")))
   (assert (= tested [0 2 10 -10]))
 
+  ; Test a `branch` nested in the tester of another `branch`.
+  (setv l [])
+  (setv out (branch
+    (do
+      (.append l it)
+      (setv x it)
+      (setv out (branch
+        (do
+          (.append l it)
+          (= (- it 100) x))
+         50 "q"
+        102 "r"
+         60 "z"))
+      (.append l it)
+      out)
+    1 "a"
+    2 "b"
+    3 "c"))
+  (assert (= out "b"))
+  (print l)
+  (assert (= l [
+    1 50 102 60 1
+    2 50 102 2]))
+
   ; Test `ebranch`.
   (defn f [x]
     (setv (cut tested) [])

--- a/tests/test_control.hy
+++ b/tests/test_control.hy
@@ -186,13 +186,27 @@
     else (+= out "f"))
   (assert (= out "c"))
 
+  ; Each case is evaluated at most once, even if `it` appears several
+  ; times in the matcher.
   (setv tested [])
+  (defn atest [x]
+    (.append tested x)
+    x)
+  (assert (= "d" (branch (and (> (* it it) 5) (< it 0))
+    (atest 0) "a"
+    (atest 2) "b"
+    (atest 10) "c"
+    (atest -10) "d"
+    (atest -6) "e")))
+  (assert (= tested [0 2 10 -10]))
+
+  ; Test `ebranch`.
   (defn f [x]
     (setv (cut tested) [])
     (ebranch (= it x)
-      (do (.append tested 1) 1) "a"
-      (do (.append tested 2) 2) "b"
-      (do (.append tested 3) 3) "c"))
+      (atest 1) "a"
+      (atest 2) "b"
+      (atest 3) "c"))
   (assert (= (f 2) "b"))
   (assert (= tested [1 2]))
   (assert (= (f 1) "a"))


### PR DESCRIPTION
I added a test in response to @allison-casey's comment on #24. While I was thinking about `it`, I also swapped out the use of `recur-sym-replace` for `let`, which improves behavior in case of nested matchers. I wanted to do the same thing for `hyrule.anaphoric` ([patch](https://github.com/hylang/hyrule/files/8008255/0001-let-in-anaphoric.txt)), but then I hit https://github.com/hylang/hy/issues/2224.