### PR TITLE
Make `#%` detect dotted fields

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -24,6 +24,7 @@ Bug Fixes
 * Destructuring macros now consistently return `None` in case of
   failing to match a certain pattern, instead of sometimes returning
   `None` and sometimes raising an exception.
+* `#%` reader macro now parses `%i` names from dotted symbols.
 
 0.1 (released 2022-01-09)
 ==============================

--- a/hyrule/anaphoric.hy
+++ b/hyrule/anaphoric.hy
@@ -227,19 +227,22 @@ concise and easy to read.
   (setv %symbols (sfor a (flatten [expr])
                        :if (and (isinstance a hy.models.Symbol)
                                 (.startswith a '%))
-                       a))
+                       (-> a
+                           (.split "." :maxsplit 1)
+                           (get 0)
+                           (cut 1 None))))
   `(fn [;; generate all %i symbols up to the maximum found in expr
         ~@(gfor i (range 1 (-> (lfor a %symbols
-                                     :if (.isdigit (cut a 1 None))
-                                     (int (cut a 1 None)))
+                                     :if (.isdigit a)
+                                     (int a))
                                (or #(0))
                                max
                                inc))
                 (hy.models.Symbol (+ "%" (str i))))
         ;; generate the #* parameter only if '%* is present in expr
-        ~@(when (in '%* %symbols)
+        ~@(when (in "*" %symbols)
                 '(#* %*))
         ;; similarly for #** and %**
-        ~@(when (in '%** %symbols)
+        ~@(when (in "**" %symbols)
                 '(#** %**))]
      ~expr))

--- a/tests/test_anaphoric.hy
+++ b/tests/test_anaphoric.hy
@@ -231,4 +231,6 @@
   (assert (= (#% #{%3 %2 %1} 1 3 2)
              #{3 1 2}))  ; sets are not ordered.
   (assert (= (#% "%1")
-             "%1")))
+             "%1"))
+  ;; https://github.com/hylang/hyrule/issues/36
+  (assert (= (#% %1.real 1) 1)))


### PR DESCRIPTION
Fixes #36.

I took a quick crack at fixing this via https://github.com/hylang/hy/issues/2096 instead, but it seems non-trivial.
In the meantime here's a quick fix for this specific bug.
