### PR TITLE
Use `&reader` instead of `hy.&reader` in `#/`

### DIFF
--- a/hyrule/macrotools.hy
+++ b/hyrule/macrotools.hy
@@ -183,8 +183,8 @@
 
       => (#/ os/path.basename "path/to/file")
       "file"]]
-  (.slurp-space hy.&reader)
-  (setv [mod #* ident] (.split (.read-ident hy.&reader) ".")
+  (.slurp-space &reader)
+  (setv [mod #* ident] (.split (.read-ident &reader) ".")
         imp `(hy.M ~(hy.mangle (.replace mod "/" "."))))
   (if ident
     `(. ~imp ~@(map hy.models.Symbol ident))

--- a/tests/test_macrotools.hy
+++ b/tests/test_macrotools.hy
@@ -39,7 +39,8 @@
 
 (defn test-defmacro! []
 
-  (defmacro! foo! [o!foo] `(do ~g!foo ~g!foo))
+  (defmacro! foo! [o!foo]
+    `(do ~g!foo ~g!foo))
   ;; test that o! becomes g!
   (assert (= "Hy" (foo! "Hy")))
   ;; test that o! is evaluated once only
@@ -47,7 +48,8 @@
   (foo! (+= foo 1))
   (assert (= 41 foo))
   ;; test optional args
-  (defmacro! bar! [o!a [o!b 1]] `(do ~g!a ~g!a ~g!b ~g!b))
+  (defmacro! bar! [o!a [o!b 1]]
+    `(do ~g!a ~g!a ~g!b ~g!b))
   ;; test that o!s are evaluated once only
   (bar! (+= foo 1) (+= foo 1))
   (assert (= 43 foo))


### PR DESCRIPTION
I was using `hy.&reader` directly instead of the implicit parameter `&reader`; this works but it's not the officially documented way of accessing the reader.
In any case, I'm removing `hy.&reader` in https://github.com/hylang/hy/pull/2494 so I need to fix it here.