### PR TITLE
Argmove macros `->` `->>` and `doto` work on all bare dotted names again

### DIFF
--- a/hyrule/argmove.hy
+++ b/hyrule/argmove.hy
@@ -6,7 +6,7 @@
   (defn _dotted [node]
     "Helper function to turn '.name forms into '(.name) forms"
     (if (and (isinstance node hy.models.Expression)
-             (= (cut node 2) '(. None)))
+             (= (get node 0) '.))
       `(~node)
       node)))
 

--- a/tests/test_argmove.hy
+++ b/tests/test_argmove.hy
@@ -6,6 +6,10 @@
              ["X" "B" "C" "D"])))
 
 
+(defn test-bare-dotted []
+  (assert (= (-> "a b c d" str.upper) "A B C D")))
+
+
 (defn test-tail-threading []
   (assert (= (.split (.join ", " (* 10 ["foo"])))
              (->> ["foo"] (* 10) (.join ", ") .split))))


### PR DESCRIPTION
Forgot that non-headless dotted names like `str.split` also get parsed as `Expression`s.