### PR TITLE
Silence most Sphinx warnings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,7 +10,7 @@
 * Konrad Hinsen <konrad.hinsen@fastmail.net>
 * Vladimir Gorbunov <vsg@suburban.me>
 * John Jacobsen <john@mail.npxdesigns.com>
-* rogererens <roger.erens@e-s-c.biz>
+* Roger Erens <roger.erens@e-s-c.biz>
 * Thomas Ballinger <thomasballinger@gmail.com>
 * Morten Linderud <mcfoxax@gmail.com>
 * Guillermo Vayá <guivaya@gmail.com>
@@ -21,13 +21,12 @@
 * Henrique Carvalho Alves <hcarvalhoalves@gmail.com>
 * Joe Hakim Rahme <joehakimrahme@gmail.com>
 * Kenan Bölükbaşı <kenanbolukbasi@gmail.com>
-* Abhishek L <abhishek.lekshmanan@gmail.com>
+* Abhishek Lekshmanan <abhishek.lekshmanan@gmail.com>
 * Christopher Browne <cbbrowne@ca.afilias.info>
 * Clinton N. Dreisbach <crnixon@gmail.com>
-* D. Joe <deejoe+castanea@etrumeus.com>
 * Duncan McGreggor <duncan.mcgreggor@rackspace.com>
 * E. Anders Lannerback <anders@lannerback.net>
-* Jack <jackjrabbit+github@gmail.com>
+* Jack Laxson <jackjrabbit+github@gmail.com>
 * Johan Euphrosine <proppy@google.com>
 * Kevin Zita <kzita@kent.edu>
 * Matt Fenwick <mfenwick100@gmail.com>
@@ -41,7 +40,7 @@
 * Brian McKenna <brian@brianmckenna.org>
 * Halit Alptekin <info@halitalptekin.com>
 * Richard Parsons <richard.lee.parsons@gmail.com>
-* han semaj <sangho.nah@gmail.com>
+* Sangho Na <sangho.nah@gmail.com>
 * Ryan Gonzalez <rymg19@gmail.com>
 * Brendan Curran-Johnson <brendan@bcjbcj.ca>
 * Ivan Kozik <ivan@ludios.org>
@@ -90,7 +89,7 @@
 * Yigong Wang <wang@yigo.ng>
 * Oskar Kvist <oskar.kvist@gmail.com>
 * Brandon T. Willard <brandonwillard@gmail.com>
-* Andrew R. M. <nixy@nixy.moe>
+* Andrew Miller <nixy@nixy.moe>
 * Tristan de Cacqueray <tdecacqu@redhat.com>
 * Sören Tempel <soeren@soeren-tempel.net>
 * Noah Snelson <noah.snelson@protonmail.com>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,10 @@
 import sys, os; sys.path.insert(0, os.path.abspath('..'))
   # Read the Docs needs this bit to import Hyrule.
 
+import warnings; import sphinx.deprecation
+warnings.filterwarnings('ignore', category = sphinx.deprecation.RemovedInSphinx60Warning)
+warnings.filterwarnings('ignore', category = sphinx.deprecation.RemovedInSphinx70Warning)
+
 html_title = 'The Hyrule manual'
 
 extensions = [

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -127,7 +127,7 @@ Reference
 
 ``misc`` — Everything else
 ----------------------------------------------------------------------
-.. hy:automodule:: misc
+.. hy:automodule:: hyrule.misc
 
 .. hy:automacro:: comment
 .. hy:autofunction:: constantly

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,7 +64,6 @@ Reference
 .. hy:automacro:: do-n
 .. hy:automacro:: ebranch
 .. hy:automacro:: ecase
-.. hy:automacro:: ifp
 .. hy:automacro:: lif
 .. hy:automacro:: list-n
 .. hy:automacro:: loop

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Pygments == 2.15.1
+Pygments @ git+https://github.com/Kodiologist/pygments@hylex
 Sphinx == 5.0.2
 sphinx_rtd_theme == 1.2.2
 git+https://github.com/hylang/sphinxcontrib-hydomain.git


### PR DESCRIPTION
That's only "most" because I still see

```
docstring of hyrule.control.lif:1: WARNING: hy:func reference target not found: if
docstring of hyrule.control.unless:1: WARNING: hy:func reference target not found: if
```

These arise because the entry for `if` in Hy comes out a bit malformed. That will have to be fixed in Hy or in sphinxcontrib-hydomain.