### PR TITLE
Edit `flatten`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -19,6 +19,8 @@ New Features
 * New macro `pun`.
 * New macro `map-hyseq`.
 * `loop` allows more kinds of parameters.
+* `flatten`, given a non-collection, returns it as a singleton list,
+  instead of raising an error.
 
 Bug Fixes
 ------------------------------

--- a/hyrule/iterables.hy
+++ b/hyrule/iterables.hy
@@ -52,20 +52,30 @@
 
 
 (defn flatten [coll]
-  #[=[Recurisvely collect all the elements and subelements of ``coll`` into a
-  single list. :hy:func:`coll?` is used to decide whether objects should be
-  descended into. ::
+  #[=[Recurisvely collect all the elements and subelements of ``coll``,
+  depth-first, and return them in a single list. :hy:func:`coll?` is used to
+  decide whether objects should be descended into. ::
+
 
     (flatten ["foo" #(1 2) [1 [2 3] 4] "bar"])
-      ; => ["foo" 1 2 1 2 3 4 "bar"]]=]
-  (if (coll? coll)
-    (_flatten coll [])
-    (raise (TypeError (.format "{0!r} is not a collection" coll)))))
+      ; => ["foo" 1 2 1 2 3 4 "bar"]
+
+  Since iteration is used to collect the elements of ``coll``, dictionaries
+  are reduced to lists of keys::
+
+    (flatten [{"a" 1  "b" 2} {"c" 3  "d" 4}])
+      ; => ["a" "b" "c" "d"]
+
+  If ``coll`` isn't a collection at all, it's returned in a singleton list::
+
+    (flatten "hello")
+      ; => ["hello"]]=]
+  (_flatten coll []))
 
 (defn _flatten [coll result]
   (if (coll? coll)
-    (do (for [b coll]
-          (_flatten b result)))
+    (for [x coll]
+      (_flatten x result))
     (.append result coll))
   result)
 

--- a/tests/test_iterables.hy
+++ b/tests/test_iterables.hy
@@ -57,19 +57,16 @@
 
 
 (defn test-flatten []
-  (setv res (flatten [1 2 [3 4] 5]))
-  (assert (= res [1 2 3 4 5]))
-  (setv res (flatten ["foo" #(1 2) [1 [2 3] 4] "bar"]))
-  (assert (= res ["foo" 1 2 1 2 3 4 "bar"]))
-  (setv res (flatten [1]))
-  (assert (= res [1]))
-  (setv res (flatten []))
-  (assert (= res []))
-  (setv res (flatten #(1)))
-  (assert (= res [1]))
-  ;; test with None
-  (setv res (flatten #(1 #(None 3))))
-  (assert (= res [1 None 3]))
+  (assert (=
+    (flatten [1 2 [3 4] 5])
+    [1 2 3 4 5]))
+  (assert (=
+    (flatten ["foo" #(1 2) [1 [2 3] 4] "bar"])
+    ["foo" 1 2 1 2 3 4 "bar"]))
+  (assert (= (flatten [1]) [1]))
+  (assert (= (flatten []) []))
+  (assert (= (flatten #(1)) [1]))
+  (assert (= (flatten #(1 #(None 3))) [1 None 3]))
   (try (flatten "foo")
        (except [e [TypeError]] (assert (in "not a collection" (str e)))))
   (try (flatten 12.34)

--- a/tests/test_iterables.hy
+++ b/tests/test_iterables.hy
@@ -63,14 +63,13 @@
   (assert (=
     (flatten ["foo" #(1 2) [1 [2 3] 4] "bar"])
     ["foo" 1 2 1 2 3 4 "bar"]))
+  (assert (= (flatten "foo") ["foo"]))
+  (assert (= (flatten 12.34) [12.34]))
   (assert (= (flatten [1]) [1]))
   (assert (= (flatten []) []))
   (assert (= (flatten #(1)) [1]))
   (assert (= (flatten #(1 #(None 3))) [1 None 3]))
-  (try (flatten "foo")
-       (except [e [TypeError]] (assert (in "not a collection" (str e)))))
-  (try (flatten 12.34)
-       (except [e [TypeError]] (assert (in "not a collection" (str e))))))
+  (assert (= (flatten {"a" 1 "b" 2}) ["a" "b"])))
 
 
 (defn test-rest []


### PR DESCRIPTION
- Closes #3

I've changed `flatten` a bit but left its behavior largely the same, including returning only the keys of dictionaries. Here's my thinking. The exact way that the user would like to recursively descend into various data structures probably depends on the structure. This function is supposed to be represent a naive approach that just does the simplest useful thing, leaving more specialized notions of flattening to the user. In general, it should be easier to write a new recursive function for specialized cases than to use some customizable interface that we add to `flatten`.