### PR TITLE
`defmacro!` no longer crashes when modifying arguments

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -13,6 +13,7 @@ Bug Fixes
 * A lot of incompatibilities of `meth`, `ameth`, `defn+`, and `fn+`
   with the core `defn` and `fn` have been fixed. You can now use `:async`,
   docstrings are recognized properly, etc.
+* `defmacro!` no longer crashes when mutating macro arguments.
 
 0.8.0 (released 2025-01-08)
 ======================================================

--- a/tests/test_macrotools.hy
+++ b/tests/test_macrotools.hy
@@ -85,6 +85,27 @@
   (assert (= (m (f)) 6)))
 
 
+(defn test-defmacro!-modify-args []
+  ;; https://github.com/hylang/hyrule/issues/112
+  ;; test that modifying args compiles
+  (defmacro! foo [x]
+    (+= x 1)
+    x)
+  (assert (= (foo 1) 2))
+  ;; test optional/default args
+  (defmacro! bar [x [y 0]]
+    (+= y 1)
+    y)
+  (assert (= (bar 2) 1))
+  (assert (= (bar 2 3) 4))
+  ;; test unpack-iterable args
+  (defmacro! baz [o!x #* ys]
+    (+= ys #(3))
+    `(+ ~g!x ~g!x ~(. ys [-1])))
+  (setv z 9)
+  (assert (= (baz (do (+= z 1) z) bing bang bong)) 23))
+
+
 (defmacro foo-walk []
   42)
 


### PR DESCRIPTION
Fixes #112.
