### PR TITLE
Add double-discard reader macro `#__`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -110,3 +110,4 @@
 * John Blundell <jlobblet@jlobblet.co.uk>
 * Artur Wroblewski <wrobell@riseup.net>
 * Mika Allert <mallert2@bloomberg.net>
+* Kevin M Granger <py@kmg.fyi>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,6 +9,7 @@ New Features
 ------------------------------
 * New functions ``sqlite-db``, ``sqlq``.
 * New macro ``sqlexec``.
+* New reader macro ``#__``. Similar to ``#_``, but discards the next *two* forms.
 
 1.0.1 (released 2025-11-19)
 ======================================================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -157,6 +157,7 @@ API
 .. hy:autofunction:: sign
 .. hy:automacro:: smacrolet
 .. hy:autofunction:: xor
+.. hy:autotag:: __
 
 Contributing to Hyrule
 ======================

--- a/hyrule/hy_init.hy
+++ b/hyrule/hy_init.hy
@@ -6,7 +6,7 @@
   hyrule.db *
   hyrule.destructure *
   hyrule.macrotools * :readers *
-  hyrule.misc *
+  hyrule.misc * :readers *
   hyrule.oop *
   hyrule.sequences *)
 (import

--- a/hyrule/misc.hy
+++ b/hyrule/misc.hy
@@ -231,3 +231,17 @@
     (.add scope target (str value)))
   (with [scope]
     (.compile _hy_compiler `(do ~@body))))
+
+(defreader __
+  #[=[Discard the following two forms. This reader macro is useful for commenting out keyword arguments or dictionary entries.
+  ::
+
+    {"one" 1 #__ "two" 2} ; => {"one" 1}
+    (dict #__ :kw1 1 :kw2 2) ; => {"kw2" 2}
+
+  ]=]
+
+  (.parse-one-form &reader)
+  (.parse-one-form &reader)
+  None
+  )

--- a/tests/test_misc.hy
+++ b/tests/test_misc.hy
@@ -1,5 +1,5 @@
 (require
-  hyrule [comment of pun smacrolet])
+  hyrule [comment of pun smacrolet] :readers [__])
 (import
   sys
   pytest
@@ -142,3 +142,25 @@
       a)
     1))
   (assert (= C.a 2)))
+
+(defn test-double-discard []
+    ; simple
+    (assert (= '(#__ 1 2) '()))
+    (assert (= '(#__ 1 2 3) '(3)))
+    (assert (= '(#__ 1 2 #__ 3 4) '()))
+    ; double
+    (assert (= '(#__ #__ 1 2 3 4 5) '(5)))
+    ; inner
+    (assert (= '(0 #__ 1 2) '(0)))
+    (assert (= '(0 #__ 1 2 #__ 3 4) '(0)))
+    (assert (= '(#__ 1 2 3 #__ 4 5) '(3)))
+    ; nested
+    (assert (= '(1 2 #__ (#__ 3 4) 5 6) '(1 2 6)))
+    ; discard with other prefix syntax
+    (assert (= '(a #__ 'b 'c d) '(a d)))
+    (assert (= '(a '#__ b c d) '(a 'd)))
+    (assert (= '(a '#__ b c #__ d e f) '(a 'f)))
+    (assert (= '(a '#__ #__ b c d e f) '(a 'f)))
+    ; keywords
+    (assert (= '(f #__ :kw val :kw2 val2) '(f :kw2 val2)))
+)


### PR DESCRIPTION
Ported over from https://github.com/hylang/hy/pull/2689

You know what's even cooler than discarding a form? Discarding _two_ forms.

If it should be easy to discard a single argument to something, it should also be easy to discard a key-value pair (be it a dictionary literal or function keyword arguments).